### PR TITLE
Implement temporary splunk workaround

### DIFF
--- a/DA-ESS-CbResponse/bin/binary_search.py
+++ b/DA-ESS-CbResponse/bin/binary_search.py
@@ -1,4 +1,4 @@
-from cbhelpers import CbSearchCommand
+from cbhelpers import CbSearchCommand, CbSearchCommand2
 from cbapi.response import Binary
 
 import sys
@@ -7,8 +7,8 @@ import logging
 log = logging.getLogger(__name__)
 
 
-@Configuration(distributed=False)
-class BinarySearchCommand(CbSearchCommand):
+@Configuration()
+class BinarySearchCommand(CbSearchCommand2):
     field_names = ['digsig_publisher', 'digsig_result', 'digsig_sign_time', 'host_count', 'is_executable_image',
                    'last_seen', 'original_filename', 'os_type', 'product_name', 'product_version', 'md5']
     search_cls = Binary

--- a/DA-ESS-CbResponse/bin/cbhelpers.py
+++ b/DA-ESS-CbResponse/bin/cbhelpers.py
@@ -2,7 +2,7 @@ from cbapi import CbApi
 from cbapi.response import CbEnterpriseResponseAPI
 from cbapi.errors import ApiError
 
-from splunklib.searchcommands import GeneratingCommand, Option, Configuration
+from splunklib.searchcommands import GeneratingCommand, Option, Configuration, EventingCommand
 import json
 import time
 import logging
@@ -96,6 +96,73 @@ class CbSearchCommand(GeneratingCommand):
         except Exception as e:
             yield self.error_event("error searching for {0} in Cb Response: {1}".format(self.query, str(e)))
 
+
+##  ---------- fixup -------------
+
+class CbSearchCommand2(EventingCommand):
+    query = Option(name="query", require=False)
+    max_result_rows = Option(name="maxresultrows", default=1000)
+
+    field_names = []
+    search_cls = None
+
+    def __init__(self):
+        super(CbSearchCommand2, self).__init__()
+        self.setup_complete = False
+        self.cb = None
+
+    def error_event(self, comment):
+        error_text = {"Error": comment}
+
+        return {'sourcetype': 'bit9:carbonblack:json', '_time': time.time(), 'source': self.cb.credentials.url,
+                '_raw': json.dumps(error_text)}
+
+    def prepare(self):
+        try:
+            self.cb = get_cbapi(self.service)
+        except KeyError:
+            self.logger.exception("API key not set")
+        except ApiError:
+            self.logger.exception("Could not contact Cb Response server")
+        except Exception:
+            self.logger.exception("Error reading API key from credential storage")
+        else:
+            self.setup_complete = True
+
+    def process_data(self, data_dict):
+        """
+        If you want to modify the data dictionary before returning to splunk, override this. // BSJ 2016-08-30
+        """
+        return data_dict
+
+    def squash_data(self, data_dict):
+        for x in data_dict.keys():
+            v = data_dict[x]
+            data_dict[x] = str(v)
+        return data_dict
+
+    def generate_result(self, data):
+        rawdata = dict( (field_name, getattr(data, field_name, "")) for field_name in self.field_names)
+        squashed_data = self.squash_data( self.process_data(rawdata) )
+        return {'sourcetype': 'bit9:carbonblack:json', '_time': time.time(),
+                'source': self.cb.credentials.url, '_raw': squashed_data}
+
+    def transform(self, results):
+        try:
+            query = self.cb.select(self.search_cls)
+            if self.query:
+                query = query.where(self.query)
+
+            for result in query[:int(self.max_result_rows)]:
+                self.logger.info("yielding {0} {1}".format(self.search_cls.__name__, result._model_unique_id))
+                yield self.generate_result(result)
+
+        except Exception as e:
+            yield self.error_event("error searching for {0} in Cb Response: {1}".format(self.query, str(e)))
+
+
+
+## -------------------------------
 
 ## Setup the logger
 def setup_logger():

--- a/DA-ESS-CbResponse/bin/process_search.py
+++ b/DA-ESS-CbResponse/bin/process_search.py
@@ -1,4 +1,4 @@
-from cbhelpers import CbSearchCommand
+from cbhelpers import CbSearchCommand, CbSearchCommand2
 from cbapi.response import Process
 
 import sys
@@ -7,8 +7,8 @@ import logging
 log = logging.getLogger(__name__)
 
 
-@Configuration(distributed=False)
-class ProcessSearchCommand(CbSearchCommand):
+@Configuration()
+class ProcessSearchCommand(CbSearchCommand2):
     field_names = ['cmdline',
                    'comms_ip',
                    'hostname',

--- a/DA-ESS-CbResponse/bin/sensor_search.py
+++ b/DA-ESS-CbResponse/bin/sensor_search.py
@@ -1,14 +1,15 @@
-from cbhelpers import CbSearchCommand
+from cbhelpers import CbSearchCommand, CbSearchCommand2
 from cbapi.response import Sensor
 
 import sys
-from splunklib.searchcommands import dispatch, GeneratingCommand, Configuration, Option
+from splunklib.searchcommands import dispatch, GeneratingCommand, Configuration, Option, EventingCommand
 import logging
 log = logging.getLogger(__name__)
 
 
-@Configuration(distributed=False)
-class SensorSearchCommand(CbSearchCommand):
+#@Configuration(distributed=False)
+@Configuration()
+class SensorSearchCommand(CbSearchCommand2):
     field_names = [
                     'build_version_string',
                     'clock_delta',


### PR DESCRIPTION
`GeneratingCommand` would not honor the `distributed=False` configuration and so searches were executing on all indexers. This workaround uses the `EventingCommand` base class instead, which will not execute on a distributed cluster.